### PR TITLE
[feat#364] 관리자 로그인 시 사원번호를 활용한 인증코드 발급 기능 구현

### DIFF
--- a/Backend/Heroes/src/main/java/com/hq/heroes/common/controller/EmailController.java
+++ b/Backend/Heroes/src/main/java/com/hq/heroes/common/controller/EmailController.java
@@ -1,5 +1,7 @@
 package com.hq.heroes.common.controller;
 
+import com.hq.heroes.auth.entity.Employee;
+import com.hq.heroes.auth.repository.EmployeeRepository;
 import com.hq.heroes.common.dto.EmailMessage;
 import com.hq.heroes.common.dto.EmailReqDTO;
 import com.hq.heroes.common.dto.EmailResDTO;
@@ -13,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Optional;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/mails")
@@ -20,13 +24,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class EmailController {
 
     private final EmailService emailService;
+    private final EmployeeRepository employeeRepository;
 
     // 임시 비밀번호 발급
     @PostMapping("/password")
     @Operation(summary = "임시 비밀번호 발급", description = "임시 비밀번호를 발급하여 메일로 전송한다.")
     public ResponseEntity<Void> sendPasswordMail(@RequestBody EmailReqDTO emailReqDTO) {
+
+        Optional<Employee> employee = employeeRepository.findByEmployeeId(emailReqDTO.getEmployeeId());
+
+        String email = employee.get().getEmail();
+
         EmailMessage emailMessage = EmailMessage.builder()
-                .to(emailReqDTO.getEmail())
+                .to(email)
                 .subject("[HQ-HeRoes] 임시 비밀번호 발급")
                 .build();
 
@@ -39,8 +49,13 @@ public class EmailController {
     @PostMapping("/email")
     @Operation(summary = "인증 코드 발급", description = "인증 코드를 발급하여 메일로 전송한다.")
     public ResponseEntity<Void> sendAuthCodeMail(@RequestBody EmailReqDTO emailReqDTO) {
+
+        Optional<Employee> employee = employeeRepository.findByEmployeeId(emailReqDTO.getEmployeeId());
+
+        String email = employee.get().getEmail();
+
         EmailMessage emailMessage = EmailMessage.builder()
-                .to(emailReqDTO.getEmail())
+                .to(email)
                 .subject("[HQ-HeRoes]이메일 인증을 위한 인증 코드 발송")
                 .build();
 

--- a/Backend/Heroes/src/main/java/com/hq/heroes/common/dto/EmailReqDTO.java
+++ b/Backend/Heroes/src/main/java/com/hq/heroes/common/dto/EmailReqDTO.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 @Getter
 public class EmailReqDTO {
 
-    private String email;
+    private String employeeId;
 
 }

--- a/Backend/Heroes/src/main/java/com/hq/heroes/common/service/EmailServiceImpl.java
+++ b/Backend/Heroes/src/main/java/com/hq/heroes/common/service/EmailServiceImpl.java
@@ -42,7 +42,7 @@ public class EmailServiceImpl implements EmailService {
         else if (type.equals("/mails/authCode")) {
             // Redis에 인증 코드 저장
             String email = emailMessage.getTo();
-            redisTemplate.opsForValue().set(email, authCode, 10, TimeUnit.MINUTES);  // 10분 만료 시간 설정
+            redisTemplate.opsForValue().set(email, authCode, 3, TimeUnit.MINUTES);  // 10분 만료 시간 설정
 
             String checkAuthCode = getAuthCode(email); // 인증 코드 조회
             log.debug("저장된 인증 코드: {}", checkAuthCode);

--- a/Frontend/src/views/pages/auth/AdminLoginPage.vue
+++ b/Frontend/src/views/pages/auth/AdminLoginPage.vue
@@ -1,103 +1,116 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import axios from 'axios';
 import router from '@/router';
 import adminService from '../auth/service/authService';
-const adminCode = ref('');
+
+const employeeId = ref('');
 const password = ref('');
-const otpCode = ref('');
-const email = ref('');
+const authCode = ref('');
+const isLoading = ref(false); // 로딩 상태
+const authCodeTimer = ref(null); // 타이머 상태
+const timeRemaining = ref(0); // 남은 시간
 
 const handleAdminLogin = async () => {
-    if (!adminCode.value || !password.value || !otpCode.value) {
-        alert('로그인 정보를 입력해주세요.');
-        return;
-    }
+  if (!employeeId.value || !password.value || !authCode.value) {
+    alert('로그인 정보를 입력해주세요.');
+    return;
+  }
 
-    try {
-        const response = await adminService.adminLogin(adminCode.value, password.value, otpCode.value);
+  if (timeRemaining.value <= 0) {
+    alert('인증코드가 만료되었습니다. 다시 요청해주세요.');
+    return;
+  }
 
-        if (response.success) {
-            alert('로그인 성공');
-            router.push('/'); // 관리자 대시보드로 이동
-        }
-    } catch (error) {
-        alert('로그인 실패: ' + error.message);
+  try {
+    const response = await adminService.adminLogin(employeeId.value, password.value, authCode.value);
+
+    if (response.success) {
+      alert('로그인 성공');
+      router.push('/'); // 메인으로 이동
     }
+  } catch (error) {
+    alert('로그인 실패: ' + error.message);
+  }
 };
 
+const requestAuthCode = async () => {
+  if (!employeeId.value) {
+    alert('사원 번호를 입력해주세요.');
+    return;
+  }
 
-const requestOTP = async () => {
-    if (!email.value) {
-        alert('이메일을 입력해주세요.');
-        return;
-    }
+  isLoading.value = true; // 로딩 시작
 
-    try {
-        await axios.post('http://localhost:8080/mails/email', {
-            email: email.value // Send email to get OTP
-        });
-        alert('OTP가 이메일로 전송되었습니다.');
-    } catch (error) {
-        alert('OTP 요청 실패: ' + (error.response?.data?.message || '알 수 없는 오류'));
+  try {
+    await axios.post('http://localhost:8080/mails/email', {
+      employeeId: employeeId.value
+    });
+
+    alert('인증코드가 이메일로 전송되었습니다.');
+    startAuthCodeTimer(); // 타이머 시작
+  } catch (error) {
+    alert('인증코드 요청 실패: ' + (error.response?.data?.message || '알 수 없는 오류'));
+  } finally {
+    isLoading.value = false; // 로딩 종료
+  }
+};
+
+const startAuthCodeTimer = () => {
+  timeRemaining.value = 180; // 3분 (180초)
+
+  if (authCodeTimer.value) {
+    clearInterval(authCodeTimer.value); // 기존 타이머 초기화
+  }
+
+  authCodeTimer.value = setInterval(() => {
+    if (timeRemaining.value > 0) {
+      timeRemaining.value -= 1;
+    } else {
+      clearInterval(authCodeTimer.value);
     }
+  }, 1000);
 };
 
 const goToLogin = () => router.push('/login');
 </script>
 
 <template>
-    <div class="relative flex items-center justify-center min-h-screen bg-surface-50 dark:bg-surface-950">
-        <div class="relative z-10 flex flex-col items-center justify-center bg-surface-0 dark:bg-surface-900 p-8 sm:p-20 rounded-lg shadow-lg">
-            <div class="text-center mb-8">
-                <div class="text-surface-900 dark:text-surface-0 text-4xl font-medium mb-4">HeRoes</div>
-                <span class="text-muted-color font-medium">관리자 로그인</span>
-            </div>
-            <div>
-                <label for="adminCode" class="block text-surface-900 dark:text-surface-0 text-xl font-medium mb-2">관리자 코드</label>
-                <InputText id="adminCode" type="text" placeholder="관리자 코드를 입력해주세요." class="w-full md:w-[30rem] mb-4" v-model="adminCode" />
+  <div class="relative flex items-center justify-center min-h-screen bg-surface-50 dark:bg-surface-950">
+    <div
+      class="relative z-10 flex flex-col items-center justify-center bg-surface-0 dark:bg-surface-900 p-8 sm:p-20 rounded-lg shadow-lg">
+      <div class="text-center mb-8">
+        <div class="text-surface-900 dark:text-surface-0 text-4xl font-medium mb-4">HeRoes</div>
+        <span class="text-muted-color font-medium">관리자 로그인</span>
+      </div>
+      <div>
+        <label for="employeeId" class="block text-surface-900 dark:text-surface-0 text-xl font-medium mb-2">사원
+          번호</label>
+        <InputText id="employeeId" type="text" placeholder="사원 번호를 입력해주세요." class="w-full md:w-[30rem] mb-4"
+          v-model="employeeId" />
 
-                <label for="adminPassword" class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">비밀번호</label>
-                <Password id="adminPassword" v-model="password" placeholder="비밀번호를 입력해주세요." :toggleMask="true" class="mb-4" fluid :feedback="false"></Password>
+        <label for="adminPassword"
+          class="block text-surface-900 dark:text-surface-0 font-medium text-xl mb-2">비밀번호</label>
+        <Password id="adminPassword" v-model="password" placeholder="비밀번호를 입력해주세요." :toggleMask="true" class="mb-4"
+          fluid :feedback="false"></Password>
 
-                <div class="flex flex-row items-center justify-center">
-                    <label for="email" class="block text-surface-900 dark:text-surface-0 text-xl font-medium">이메일</label>
-                    <InputText id="email" v-model="email" placeholder="이메일을 입력해주세요." class="mb-4 mt-2 w-full" />
-                </div>
-
-                <div class="flex flex-row items-center justify-center">
-                    <label for="adminNo" class="block text-surface-900 dark:text-surface-0 text-xl font-medium">OTP</label>
-                    <span class="font-medium no-underline text-right cursor-pointer hover:text-primary ml-auto" @click="requestOTP">OTP 발급</span>
-                </div>
-                <InputOtp class="mb-4 mt-2" v-model="otpCode" :length="6"></InputOtp>
-
-                <div class="flex flex-col items-center">
-                    <Button label="Login" class="w-full" @click="handleAdminLogin"></Button>
-                    <span class="font-medium no-underline mt-3 text-right cursor-pointer hover:text-primary" @click="goToLogin">사원 로그인</span>
-                </div>
-            </div>
+        <div class="flex flex-row items-center justify-center">
+          <label for="adminNo" class="block text-surface-900 dark:text-surface-0 text-xl font-medium">인증코드</label>
+          <span class="font-medium no-underline text-right cursor-pointer hover:text-primary ml-auto"
+            @click="requestAuthCode" :disabled="isLoading">{{ isLoading ? '발급 중...' : '인증코드 발급' }}</span>
         </div>
+        <InputOtp class="mb-4 mt-2" v-model="authCode" :length="6"></InputOtp>
+
+        <div v-if="timeRemaining > 0" class="text-xxl text-muted">남은 시간: {{ Math.floor(timeRemaining / 60) }}분 {{
+          timeRemaining % 60 }}초</div>
+        <div v-else-if="timeRemaining === 0" class="text-xxl text-red-500">사원 번호와 비밀번호를 입력 후 인증코드를 발급해주세요.</div>
+
+        <div class="flex flex-col items-center">
+          <Button label="Login" class="w-full mt-3" @click="handleAdminLogin"></Button>
+          <span class="font-medium no-underline mt-3 text-right cursor-pointer hover:text-primary" @click="goToLogin">사원
+            로그인</span>
+        </div>
+      </div>
     </div>
+  </div>
 </template>
-
-<style scoped>
-.pi-eye {
-    transform: scale(1.6);
-    margin-right: 1rem;
-}
-
-.pi-eye-slash {
-    transform: scale(1.6);
-    margin-right: 1rem;
-}
-
-.absolute {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-}
-
-.relative.z-10 {
-    z-index: 10;
-}
-</style>


### PR DESCRIPTION
## 📢 기능 설명
관리자 로그인 시 사원번호를 활용한 인증코드 발급 기능 구현
![image](https://github.com/user-attachments/assets/76b34d3f-c956-42c4-9be8-5a8b689ece73)
인증코드 발급중

![image](https://github.com/user-attachments/assets/3f35d846-021b-4a04-acf6-96d9aeb5d289)
인증코드 발급이 완료 되면 3분의 유효기간이 주어짐

![image](https://github.com/user-attachments/assets/1a21da70-badc-496c-802e-5e6ba7bb0b43)
email로 인증코드 보냄

![image](https://github.com/user-attachments/assets/1e542cd6-2c8e-4718-ba2f-3758c817cda9)
인증코드까지 맞게 되면 로그인 성공
<br>

## 연결된 issue
연결된 Issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #364 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
  - ex) [feat/#21] 회원 로그인 기능부분 구현
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 