### PR TITLE
[design/#693] 교육 페이지 수정

### DIFF
--- a/Frontend/src/layout/AppMenu.vue
+++ b/Frontend/src/layout/AppMenu.vue
@@ -9,8 +9,10 @@ const model = ref([
                 label: '관리자 기능',
                 icon: 'pi pi-key',
                 items: [
+                    { label: '사원 등록', icon: 'pi pi-fw pi-user-plus', to: '/signup' },
                     { label: '사원 정보 수정', icon: 'pi pi-fw pi-user-edit', to: '/update-emp-info' },
                     { label: '교육 관리', icon: 'pi pi-fw pi-book', to: '/manage-education' },
+                    { label: '교육 승인', icon: 'pi pi-fw pi-calendar-minus', to: '/approve-education' },
                     { label: '자격증 관리', icon: 'pi pi-fw pi-credit-card', to: '/manage-certifications' },
                     { label: '평가 기준 관리', icon: 'pi pi-fw pi-chart-bar', to: '/manage-evaluation-criteria' }
                 ]
@@ -73,7 +75,6 @@ const model = ref([
                     { label: '교육 신청', icon: 'pi pi-fw pi-calendar-plus', to: '/education-apply' },
                     { label: '교육 이력', icon: 'pi pi-fw pi-calendar-minus', to: '/education-history' },
                     { label: '자격증 관리', icon: 'pi pi-fw pi-id-card', to: '/certificate-management' },
-                    { label: '교육 승인', icon: 'pi pi-fw pi-calendar-minus', to: '/approve-education' }
                 ]
             },
             {

--- a/Frontend/src/views/pages/education/education-management/EducationDetailModal.vue
+++ b/Frontend/src/views/pages/education/education-management/EducationDetailModal.vue
@@ -34,8 +34,12 @@
         </div>
 
         <template #footer>
-            <!-- courseStatus가 '이수'가 아닐 때만 취소하기 버튼을 보여줌 -->
-            <Button v-if="mapStatus(courseDetail.courseStatus) !== '이수'" label="취소하기" severity="danger" class="p-button-outlined" @click="handleCancelClick" />
+            <!-- courseStatus가 '이수'가 아니고 교육 시작일이 지나지 않았을 때만 취소하기 버튼을 보여줌 -->
+            <Button v-if="mapStatus(courseDetail.courseStatus) !== '이수' && !isCourseStarted(courseDetail.startDate)"
+                    label="취소하기"
+                    severity="danger"
+                    class="p-button-outlined"
+                    @click="handleCancelClick" />
             <Button label="닫기" class="p-button-primary" @click="closeModal" />
         </template>
     </Dialog>
@@ -64,6 +68,9 @@ const formatDate = (date) => `${date.getFullYear()}-${date.getMonth() + 1}-${dat
 
 // 상태를 텍스트로 변환하는 함수
 const mapStatus = (status) => status === 'PASS' ? '이수' : '미이수';
+
+// 교육 시작 여부 확인 함수
+const isCourseStarted = (startDate) => new Date(startDate) <= new Date();
 
 // 취소 버튼 클릭 처리 함수
 async function handleCancelClick() {
@@ -121,5 +128,4 @@ async function cancelEducation() {
     border-bottom: 1px solid #ddd;
     text-align: left;
 }
-
 </style>

--- a/Frontend/src/views/pages/education/education-management/EducationHistory.vue
+++ b/Frontend/src/views/pages/education/education-management/EducationHistory.vue
@@ -44,7 +44,7 @@
                     {{ data.educationName }}
                 </template>
             </Column>
-            <Column field="startDate" sortable header="교육 신청일" dataType="date" style="min-width: 10rem; text-align: left;">
+            <Column field="startDate" sortable header="교육 시작일" dataType="date" style="min-width: 10rem; text-align: left;">
                 <template #body="{ data }">
                     {{ formatDate(new Date(data.startDate)) }}
                 </template>


### PR DESCRIPTION
## 📢 기능 설명
- 교육 이력에서 신청일 -> 시작일로 바꾸기
![image](https://github.com/user-attachments/assets/748e2a42-5116-4bfc-99c6-0e8c9487c784)
- 교육 상세 모달에서 시작일 현재 날짜 이후면 취소 버튼 안 보이도록
![image](https://github.com/user-attachments/assets/e8548c1b-19c9-431c-9af0-a220fd113884)
- 교육 승인 페이지 관리자 기능으로 옮기기
![image](https://github.com/user-attachments/assets/a46fcfee-57b9-4fa1-bcac-2c32b3b2825e)

## 연결된 issue
연결된 Issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #693 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
  - ex) [feat/#21] 회원 로그인 기능부분 구현
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 