### PR TITLE
[design/#752] 교육 및 자격증 페이지 수정

### DIFF
--- a/Frontend/src/views/pages/admin/ManageCertificatePage.vue
+++ b/Frontend/src/views/pages/admin/ManageCertificatePage.vue
@@ -3,16 +3,7 @@
         <div class="card">
             <div class="flex flex-row justify-between mb-4">
                 <label class="text-xl font-bold">자격증 관리</label>
-                <Button
-                    label="추가하기"
-                    icon="pi pi-plus"
-                    class="custom-button"
-                    @click="
-                        () => {
-                            showAddCertification();
-                        }
-                    "
-                />
+                <Button label="추가하기" icon="pi pi-plus" class="custom-button" @click="showAddCertification" />
             </div>
 
             <!-- 필터 및 검색 섹션 -->
@@ -22,8 +13,8 @@
                     <Dropdown v-model="selectedDepartment" :options="departments" optionLabel="deptName" placeholder="부서를 선택하세요" @change="filterCertifications" class="mr-2" />
                 </div>
                 <div class="relative search-container">
-                    <InputText v-model="globalFilter" placeholder="검색" class="pl-8 search-input" />
-                    <i class="pi pi-search search-icon" />
+                    <InputText v-model="globalFilter" placeholder="검색" @input="filterCertifications" class="pl-8 search-input" />
+                    <i class="pi pi-search search-icon"></i>
                 </div>
             </div>
 
@@ -46,95 +37,93 @@
                 <Column class="w-16 !text-end">
                     <template #body="{ data }">
                         <div style="display: flex; gap: 0.5rem">
-                            <!-- flexbox와 gap 사용 -->
                             <Button icon="pi pi-pencil" @click.stop="showEditCertification(data)" severity="primary" rounded></Button>
                             <Button icon="pi pi-trash" @click.stop="confirmDeleteCertification(data)" severity="danger" rounded></Button>
                         </div>
                     </template>
                 </Column>
             </DataTable>
+
+            <!-- 자격증 조회 모달 -->
+            <Dialog v-model:visible="isDetailDialogVisible" modal header="자격증 정보" :style="{ width: '30vw', borderRadius: '12px' }" :draggable="false" :closable="false">
+                <template #header>
+                    <div class="font-bold p-2" :style="{ fontSize: '1.5rem' }">{{ selectedCertification ? selectedCertification.certificationName : '정보 없음' }}</div>
+                </template>
+                <hr />
+                <div class="p-4">
+                    <table class="education-info">
+                        <tr>
+                            <td class="px-4 py-2"><strong>부서</strong></td>
+                            <td class="px-4 py-2">{{ selectedCertification ? selectedCertification.deptName : 'N/A' }}</td>
+                        </tr>
+                        <tr>
+                            <td class="px-4 py-2"><strong>자격증 명</strong></td>
+                            <td class="px-4 py-2">{{ selectedCertification ? selectedCertification.certificationName : 'N/A' }}</td>
+                        </tr>
+                        <tr>
+                            <td class="px-4 py-2"><strong>발급 기관</strong></td>
+                            <td class="px-4 py-2">{{ selectedCertification ? selectedCertification.institution : 'N/A' }}</td>
+                        </tr>
+                        <tr>
+                            <td class="px-4 py-2"><strong>혜택</strong></td>
+                            <td class="px-4 py-2">{{ selectedCertification ? selectedCertification.benefit : 'N/A' }}</td>
+                        </tr>
+                    </table>
+                </div>
+                <template #footer>
+                    <Button label="닫기" @click="closeDialog" />
+                </template>
+            </Dialog>
+            <!-- 자격증 추가 모달 -->
+            <Dialog v-model:visible="isAddDialogVisible" modal header="자격증 추가하기" :style="{ width: '30vw', borderRadius: '12px' }" :draggable="false" :closable="false">
+                <div class="flex flex-col gap-6">
+                    <div>
+                        <Select v-model="selectedAddDepartment" :options="departments" optionLabel="deptName" placeholder="부서를 선택하세요" @change="changeSelectedAddDeptId(selectedAddDepartment.deptId)" />
+                    </div>
+                    <div>
+                        <label for="certificationName" class="block font-bold mb-3">자격증 명</label>
+                        <InputText id="certificationName" v-model="addCertificationData.certificationName" required class="w-full" placeholder="자격증 명을 입력해주세요." />
+                    </div>
+                    <div>
+                        <label for="institution" class="block font-bold mb-3">기관 명</label>
+                        <InputText id="institution" v-model="addCertificationData.institution" required class="w-full" placeholder="발급 기관을 입력해주세요" />
+                    </div>
+                    <div>
+                        <label for="benefit" class="block font-bold mb-3">혜택</label>
+                        <InputText id="benefit" v-model="addCertificationData.benefit" required class="w-full" placeholder="혜택을 입력해주세요." />
+                    </div>
+                </div>
+                <template #footer>
+                    <Button label="저장" class="p-button-primary" @click="saveCertification" />
+                    <Button label="취소" text class="p-button-text" @click="isAddDialogVisible = false" />
+                </template>
+            </Dialog>
+
+            <!-- 자격증 수정 모달 -->
+            <Dialog v-model:visible="isEditDialogVisible" modal header="자격증 수정하기" :style="{ width: '30vw', borderRadius: '12px' }" :draggable="false" :closable="false">
+                <div class="flex flex-col gap-6">
+                    <div>
+                        <Select v-model="selectedEditDepartment" :options="departments" optionLabel="deptName" placeholder="부서를 선택하세요" @change="changeSelectedEditDeptId(selectedEditDepartment.deptId)" />
+                    </div>
+                    <div>
+                        <label for="certificationName" class="block font-bold mb-3">자격증 명</label>
+                        <InputText id="certificationName" v-model="editCertificationData.certificationName" required class="w-full" placeholder="자격증 명을 입력해주세요." />
+                    </div>
+                    <div>
+                        <label for="institution" class="block font-bold mb-3">기관 명</label>
+                        <InputText id="institution" v-model="editCertificationData.institution" required class="w-full" placeholder="발급 기관을 입력해주세요" />
+                    </div>
+                    <div>
+                        <label for="benefit" class="block font-bold mb-3">혜택</label>
+                        <InputText id="benefit" v-model="editCertificationData.benefit" required class="w-full" placeholder="혜택을 입력해주세요." />
+                    </div>
+                </div>
+                <template #footer>
+                    <Button label="저장" class="p-button-primary" @click="editCertification" />
+                    <Button label="취소" text class="p-button-text" @click="isEditDialogVisible = false" />
+                </template>
+            </Dialog>
         </div>
-
-        <!-- 자격증 조회 모달 -->
-        <Dialog v-model:visible="isDetailDialogVisible" modal header="자격증 정보" :style="{ width: '30vw', borderRadius: '12px' }" :draggable="false" :closable="false">
-            <template #header>
-                <div class="font-bold p-2" :style="{ fontSize: '1.5rem' }">{{ selectedCertification ? selectedCertification.certificationName : '정보 없음' }}</div>
-            </template>
-            <hr />
-            <div class="p-4">
-                <table class="education-info">
-                    <tr>
-                        <td class="px-4 py-2"><strong>부서</strong></td>
-                        <td class="px-4 py-2">{{ selectedCertification.deptName || 'N/A' }}</td>
-                    </tr>
-                    <tr>
-                        <td class="px-4 py-2"><strong>자격증 명</strong></td>
-                        <td class="px-4 py-2">{{ selectedCertification.certificationName || 'N/A' }}</td>
-                    </tr>
-                    <tr>
-                        <td class="px-4 py-2"><strong>발급 기관</strong></td>
-                        <td class="px-4 py-2">{{ selectedCertification.institution || 'N/A' }}</td>
-                    </tr>
-                    <tr>
-                        <td class="px-4 py-2"><strong>혜택</strong></td>
-                        <td class="px-4 py-2">{{ selectedCertification.benefit || 'N/A' }}</td>
-                    </tr>
-                </table>
-            </div>
-            <template #footer>
-                <Button label="닫기" @click="isDetailDialogVisible = false" />
-            </template>
-        </Dialog>
-
-        <!-- 자격증 추가 모달 -->
-        <Dialog v-model:visible="isAddDialogVisible" modal header="자격증 추가하기" :style="{ width: '30vw', borderRadius: '12px' }" :draggable="false" :closable="false">
-            <div class="flex flex-col gap-6">
-                <div>
-                    <Select v-model="selectedDepartment" :options="departments" id="deptId" optionLabel="deptName" placeholder="부서를 선택하세요" @change="changeSelectedAddDeptId(selectedDepartment.deptId)" />
-                </div>
-                <div>
-                    <label for="certificationName" class="block font-bold mb-3">자격증 명</label>
-                    <InputText id="certificationName" v-model="addCertificationData.certificationName" required class="w-full" placeholder="자격증 명을 입력해주세요." />
-                </div>
-                <div>
-                    <label for="institution" class="block font-bold mb-3">기관 명</label>
-                    <InputText id="institution" v-model="addCertificationData.institution" required class="w-full" placeholder="발급 기관을 입력해주세요" />
-                </div>
-                <div>
-                    <label for="benefit" class="block font-bold mb-3">혜택</label>
-                    <InputText id="benefit" v-model="addCertificationData.benefit" required class="w-full" placeholder="혜택을 입력해주세요." />
-                </div>
-            </div>
-            <template #footer>
-                <Button label="저장" class="p-button-primary" @click="saveCertification" />
-                <Button label="취소" text class="p-button-text" @click="isAddDialogVisible = false" />
-            </template>
-        </Dialog>
-
-        <!-- 자격증 수정 모달 -->
-        <Dialog v-model:visible="isEditDialogVisible" modal header="자격증 수정하기" :style="{ width: '30vw', borderRadius: '12px' }" :draggable="false" :closable="false">
-            <div class="flex flex-col gap-6">
-                <div>
-                    <Select v-model="selectedDepartment" :options="departments" id="deptId" optionLabel="deptName" placeholder="부서를 선택하세요" @change="changeSelectedEditDeptId(selectedDepartment.deptId)" />
-                </div>
-                <div>
-                    <label for="certificationName" class="block font-bold mb-3">자격증 명</label>
-                    <InputText id="certificationName" v-model="editCertificationData.certificationName" required class="w-full" placeholder="자격증 명을 입력해주세요." />
-                </div>
-                <div>
-                    <label for="institution" class="block font-bold mb-3">기관 명</label>
-                    <InputText id="institution" v-model="editCertificationData.institution" required class="w-full" placeholder="발급 기관을 입력해주세요" />
-                </div>
-                <div>
-                    <label for="benefit" class="block font-bold mb-3">혜택</label>
-                    <InputText id="benefit" v-model="editCertificationData.benefit" required class="w-full" placeholder="혜택을 입력해주세요." />
-                </div>
-            </div>
-            <template #footer>
-                <Button label="저장" class="p-button-primary" @click="editCertification" />
-                <Button label="취소" text class="p-button-text" @click="isEditDialogVisible = false" />
-            </template>
-        </Dialog>
     </div>
 </template>
 
@@ -212,19 +201,38 @@ async function fetchDepartments() {
 // 선택된 부서와 전역 검색어로 필터링
 function filterCertifications() {
     filteredCertifications.value = certifications.value.filter((certification) => {
-        const matchesDept = selectedDepartment.value && selectedDepartment.value.deptName !== '전체 부서' ? certification.deptName === selectedDepartment.value.deptName : true;
-        const matchesGlobalFilter = globalFilter.value ? certification.certificationName.toLowerCase().includes(globalFilter.value.toLowerCase()) : true;
+        // 부서 매칭
+        const matchesDept = 
+            !selectedDepartment.value || 
+            selectedDepartment.value.deptName === '전체 부서' || 
+            certification.deptName === selectedDepartment.value.deptName;
+
+        // 글로벌 필터 매칭
+        const matchesGlobalFilter = globalFilter.value 
+            ? certification.certificationName.toLowerCase().includes(globalFilter.value.toLowerCase()) 
+            : true;
 
         return matchesDept && matchesGlobalFilter;
     });
 }
 
 // 자격증 조회 Dialog 띄우기
-function showCertificationDetails(event) {
-    console.log(event);
-    selectedCertification.value = event; // 클릭된 행의 데이터
-    isDetailDialogVisible.value = true; // 모달 표시
-}
+const showCertificationDetails = (event) => {
+    const certification = event.data; // 클릭한 데이터가 있는지 확인
+    console.log(certification); // 콘솔에 출력하여 데이터 확인
+    if (certification) {
+        selectedCertification.value = certification; // 선택한 자격증 정보를 설정
+        isDetailDialogVisible.value = true; // 모달을 열기
+    } else {
+        closeDialog(); // 데이터가 없을 경우 모달 닫기 및 초기화
+    }
+};
+
+// 모달을 닫을 때 선택된 항목 초기화
+const closeDialog = () => {
+    isDetailDialogVisible.value = false; // 모달 닫기
+    selectedCertification.value = null;  // 선택된 자격증 정보 초기화
+};
 
 // 자격증 추가 Dialog 띄우기
 function showAddCertification() {

--- a/Frontend/src/views/pages/admin/ManageEducationPage.vue
+++ b/Frontend/src/views/pages/admin/ManageEducationPage.vue
@@ -19,7 +19,7 @@
                     />
                 </div>
                 <div class="relative search-container">
-                    <InputText v-model="globalFilter" placeholder="검색" class="pl-8 search-input" />
+                    <InputText v-model="globalFilter" placeholder="검색" @input="filterEducations" class="pl-8 search-input" />
                     <i class="pi pi-search search-icon" />
                 </div>
             </div>
@@ -77,11 +77,18 @@ const router = useRouter();
 // 필터링 함수
 function filterEducations() {
     filteredEducations.value = educations.value.filter((education) => {
-        const matchesCategoryName = selectedcategoryName.value?.categoryName !== '전체' ? education.categoryName === selectedcategoryName.value.categoryName : true;
-        const matchesDate = selectedDate.value ? new Date(education.educationStart) <= new Date(selectedDate.value) && new Date(education.educationEnd) >= new Date(selectedDate.value) : true;
-        const matchesGlobalFilter = globalFilter.value ? education.educationName.toLowerCase().includes(globalFilter.value.toLowerCase()) : true;
+        // 카테고리 이름 매칭
+        const matchesCategoryName =
+            !selectedcategoryName.value || 
+            selectedcategoryName.value.categoryName === '전체' ||
+            education.categoryName === selectedcategoryName.value.categoryName;
 
-        return matchesCategoryName && matchesDate && matchesGlobalFilter;
+        // 글로벌 필터 매칭
+        const matchesGlobalFilter = globalFilter.value
+            ? education.educationName.toLowerCase().includes(globalFilter.value.toLowerCase())
+            : true;
+
+        return matchesCategoryName && matchesGlobalFilter;
     });
 }
 

--- a/Frontend/src/views/pages/education/certificate-management/CertificationList.vue
+++ b/Frontend/src/views/pages/education/certificate-management/CertificationList.vue
@@ -2,7 +2,7 @@
     <div class="card">
         <div class="flex flex-row justify-between mb-4">
             <label class="text-xl font-bold">자격증 목록</label>
-            <Button label="추가하기" icon="pi pi-plus" class="custom-button" @click="showAddOrUpdateDialog(null)" />
+            <Button label="등록하기" icon="pi pi-plus" class="custom-button" @click="showAddOrUpdateDialog(null)" />
         </div>
 
         <div class="grid grid-cols-12 gap-4">


### PR DESCRIPTION
## 📢 기능 설명
- 자격증 재클릭 시 상세 나오게 수정 
![image](https://github.com/user-attachments/assets/43d6bee3-8206-4aa6-9096-bef7ec05f788)
- 자격증 및 교육 관리에서 검색
![image](https://github.com/user-attachments/assets/5b9ee607-b1e8-4dda-a45c-5f27d446305c)
- 사원 자격증 추가하기 → 등록하기
![image](https://github.com/user-attachments/assets/d613a4c6-a889-41d8-a785-ebdd26bd64c2)
- 교육 작성 페이지에서 시작 날짜에 기본으로 현재 날짜가 나오게 수정/종료 날짜가 시작날짜보다 앞서지 못하게 수정
![image](https://github.com/user-attachments/assets/c5916771-ab40-430d-bb73-493b1eed2d96)

## 연결된 issue
연결된 Issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #752 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가?
  - ex) [feat/#21] 회원 로그인 기능부분 구현
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가? 